### PR TITLE
hacku2020におけるチーム名の修正および，イベント名の表記修正

### DIFF
--- a/products.html
+++ b/products.html
@@ -113,7 +113,7 @@
                   </div>
                   <div class="col-12 col-md-9 product-description">
                     <h3 class="product-name">はげましすてむ</h3>
-                    <h5 class="contest-result">at OPEN HACK U 2020（チーム今回はご参加を見送らせていただきます。）</h5>
+                    <h5 class="contest-result">at Open Hack U 2020 Online Vol.1（チーム今回はご参加を見送らせていただくこととなりました。）</h5>
                     <p class="description">お祈りメールが来たときに励ましてくれるシステム．</p>
                     <div class="product-links">
                       <nobr>


### PR DESCRIPTION
Hack U 2020のチーム名が違ったので修正した．
また，イベント名の表記をイベント公式サイトに揃えて"Open Hack U 2020 Online Vol.1"とした．