### PR TITLE
Remove Blog link

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,7 +355,6 @@
       <nav class="footer-nav">
         <ul>
           <li><a href="https://studioaquatan.esa.io/">Private Wiki</a></li>
-          <li><a href="https://esa-pages.io/p/sharing/8538/posts/613/07ca522e14a59f22a0c1.html">Blog</a></li>
           <li><a href="//twitter.com/StudioAquatan">Contact</a></li>
         </ul>
       </nav>


### PR DESCRIPTION
現在、BLOGとNEWSへのリンクが用意されていますが、内容はほとんど同じものとなっています。
NEWSへのリンクだけで十分だと思いますので、BLOGへのリンクは削除します。